### PR TITLE
[fix] Assumptions about how binaries are laid out under `node_modules`

### DIFF
--- a/identify.js
+++ b/identify.js
@@ -2,13 +2,13 @@
 
 var VERSION = require("./package.json").version,
    ARCH = require("arch")(),
-   cp = require("child_process")
+   cp = require("child_process"),
+   fs = require("fs"),
+   path = require("path")
 
 var bsc_version_regex = /(\w+)\s+(\d+\.\d+\.\d+)(-[^\s]+)?\s+\(\s*Using\s+OCaml:?(\d+\.\d+\.\d+)\+BS\s*\)/i
 
-// NOTE: This doesn't invoke a shell, and thus it doesn't consider $PATH. Intentionally.
-// I'd rather be subject to the vagaries of *just* npm, instead of both npm and the shell.
-var bsc_executable = require.resolve("bs-platform/lib/bsc.exe"),
+var bsc_executable = findExcutableSync("bsc"),
    bsc_version = cp.execFileSync(bsc_executable, ["-version"], { encoding: "utf8" }),
    mr = bsc_version.match(bsc_version_regex)
 
@@ -22,3 +22,9 @@ var OCAML = mr[4],
    hyphenated_id = ["v" + VERSION, process.platform, ARCH, OCAML].join("-")
 
 module.exports = hyphenated_id
+
+function findExcutableSync (name) {
+  for (let fullPath of process.env.PATH.split(path.delimiter).map((dir) => path.join(dir, name))) {
+    if (fs.existsSync(fullPath)) { return fullPath }
+  }
+}


### PR DESCRIPTION
Find `bsc` by walking the PATH instead. If we are being called from e.g. `npx`, the PATH should contain what we need.

Fixes #1